### PR TITLE
Fix for fetching all friends/followers

### DIFF
--- a/lib/twitter_oauth/friendships.rb
+++ b/lib/twitter_oauth/friendships.rb
@@ -2,15 +2,35 @@ module TwitterOAuth
   class Client
     
     # Returns an array of numeric IDs for every user the specified user is following.
-    def friends_ids(options={})
-      args = options.map{|k,v| "#{k}=#{v}"}.join('&')
-      get("/friends/ids.json?#{args}")
+    def friends_ids
+      user_ids = []
+      cursor = '-1'
+      while cursor != 0 do
+        json = get("/friends/ids.json?cursor=#{cursor}")
+        cursor = json['next_cursor']
+
+        # Raise errors
+        raise "#{json['request']}: #{json['error']}" if json['error']
+
+        user_ids += json['ids'] if json['ids']
+      end
+      user_ids
     end
     
     # Returns an array of numeric IDs for every user following the specified user.
-    def followers_ids(options={})
-      args = options.map{|k,v| "#{k}=#{v}"}.join('&')
-      get("/followers/ids.json?#{args}")
+    def followers_ids
+      user_ids = []
+      cursor = '-1'
+      while cursor != 0 do
+        json = get("/followers/ids.json?cursor=#{cursor}")
+        cursor = json['next_cursor']
+
+        # Raise errors
+        raise "#{json['request']}: #{json['error']}" if json['error']
+
+        user_ids += json['ids'] if json['ids']
+      end
+      user_ids
     end
     
     # Allows the authenticating user to follow the specified user. Returns the befriended user when successful.

--- a/lib/twitter_oauth/user.rb
+++ b/lib/twitter_oauth/user.rb
@@ -1,5 +1,34 @@
 module TwitterOAuth
   class Client
+    # Twitter limits /users/lookup.json to return 100 users at a time
+    USERS_LOOKUP_SIZE = 100
+
+    # Returns all Users given by array of users specified by either screen name or id
+    def lookup users = []
+      raise "No user ids specified" if users.empty?
+
+      # Determine if dealing with screen_names or ids
+      if users.first.is_a? Fixnum # dealing with user ids
+        parameter = :user_id
+      else user.first.is_a? String # dealing with screen names
+        parameter = :screen_name
+      end 
+
+      return post('/users/lookup.json', parameter => users.join(',')) if users.count <= USERS_LOOKUP_SIZE
+
+      friends = []
+
+      users.each_slice(USERS_LOOKUP_SIZE) do |user_batch|
+        json = post("/users/lookup.json", parameter => user_batch.join(','))
+
+        # Raise errors
+        raise "#{json['request']}: #{json['error']}" if json['error']
+
+        friends += json
+      end
+
+      friends
+    end
      
     # Returns the 100 last friends
     # The page parameter is implemented for legacy reasons, but use of this is slow
@@ -18,16 +47,14 @@ module TwitterOAuth
       users
     end 
 
+    # Rewritten to support new API calls - VT
     # Returns all pages of friends
     def all_friends
-      users = []
-      cursor = "-1"
-      while cursor != 0 do 
-        json = get("/statuses/friends.json?cursor=#{cursor}")
-        cursor = json["next_cursor"]
-        users += json["users"]
-      end
-      users
+      # Get Twitter friend user ids
+      ids = friends_ids
+
+      # Perform lookup for user ids
+      users = lookup ids
     end
     
     # Returns the 100 last followers
@@ -46,14 +73,11 @@ module TwitterOAuth
 
     # Returns all pages of followers
     def all_followers
-      users = []
-      cursor = "-1"
-      while cursor != 0 do 
-        json = get("/statuses/followers.json?cursor=#{cursor}")
-        cursor = json["next_cursor"]
-        users += json["users"]
-      end
-      users
+      # Get Twitter follower user ids
+      ids = followers_ids
+
+      # Perform lookup for user ids
+      users = lookup ids
     end
 
   end

--- a/lib/twitter_oauth/user.rb
+++ b/lib/twitter_oauth/user.rb
@@ -22,7 +22,7 @@ module TwitterOAuth
         json = post("/users/lookup.json", parameter => user_batch.join(','))
 
         # Raise errors
-        raise "#{json['request']}: #{json['error']}" if json['error']
+        raise "#{json['request']}: #{json['error']}" if json.is_a?(Hash) && json['error']
 
         friends += json
       end

--- a/twitter_oauth.gemspec
+++ b/twitter_oauth.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{twitter_oauth}
-  s.version = "0.4.3"
+  s.version = "0.4.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Richard Taylor"]


### PR DESCRIPTION
- Bumped Version Number
- user.rb:
  - #lookup (new):  Returns all Users given by array of users specified
    by either screen name or id
  - #all_friends: updated to support new Twitter API calls
  - #all_followers: updated to support new Twitter API calls
- friendships.rb:
  - #friends_ids: support for twitter cursors
  - #followers_ids: support for twitter cursors
