### PR TITLE
Fixed mentions endpoint url for twitter api v1.1

### DIFF
--- a/lib/twitter_oauth/timeline.rb
+++ b/lib/twitter_oauth/timeline.rb
@@ -30,7 +30,7 @@ module TwitterOAuth
     # Returns the 20 most recent @replies (status updates prefixed with @username) for the authenticating user.
     def mentions(options={})
       args = options.map{|k,v| "#{k}=#{v}"}.join('&')
-      get("/statuses/mentions.json?#{args}")
+      get("/statuses/mentions_timeline.json?#{args}")
     end
     alias :replies :mentions
     


### PR DESCRIPTION
In twitter api v1.1 mentions end_point is /statuses/mentions_timeline.json instead of /statuses/mentions.json  - https://dev.twitter.com/docs/api/1.1/get/statuses/mentions_timeline
