### PR TITLE
Updated friend and unfriend methods to match Twitter 1.1 API.

### DIFF
--- a/lib/twitter_oauth/friendships.rb
+++ b/lib/twitter_oauth/friendships.rb
@@ -15,12 +15,12 @@ module TwitterOAuth
 
     # Allows the authenticating user to follow the specified user. Returns the befriended user when successful.
     def friend(id)
-      post("/friendships/create/#{id}.json")
+      post("/friendships/create.json?user_id=#{id}&follow=true")
     end
 
     # Allows the authenticating users to unfollow the specified user. Returns the unfollowed user when successful.
     def unfriend(id)
-      post("/friendships/destroy/#{id}.json")
+      post("/friendships/destroy.json?user_id=#{id}")
     end
 
     # Tests for the existence of friendship between two users. Will return true if user_a follows user_b, otherwise will return false.


### PR DESCRIPTION
Please take a look at my update to friendships.rb modifying the friend and unfriend methods. Neither post paths worked with the 1.1 API. Thanks! Scott
